### PR TITLE
Add temporary Google Maps API access

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
-    <script src="http://maps.google.com/maps/api/js?v=3&sensor=false"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyD8D11NU8OXfx8VqjFDR0pLcL8SK0n2ZH8"></script>
     <script src="Google.js"></script>
     <script src="GoogleTraffic.js"></script>
     <script src="dist/leaflet.awesome-markers.js"></script>


### PR DESCRIPTION
Due to Google Maps API charging for calls now instead of being free, adding a temporary key limited to certain websites to allow the maps to work.